### PR TITLE
Update Booking.php

### DIFF
--- a/components/Booking.php
+++ b/components/Booking.php
@@ -198,6 +198,7 @@ class Booking extends BaseComponent
     {
         $options = [];
         $startTime = Carbon::createFromTime(00, 00, 00);
+        $startTime->addMinutes(30);
         $endTime = Carbon::createFromTime(23, 59, 59);
         $interval = new DateInterval("PT{$this->property('timePickerInterval')}M");
         $dateTimes = new DatePeriod($startTime, $interval, $endTime);


### PR DESCRIPTION
Fixed booking slot time. Now slot time show as beginning  time The time set by the user . (previously the first available table was shown half an hour before the time set by the customer.)